### PR TITLE
Resolve Github omniauth strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main [(unreleased)](https://github.com/fastruby/ombu_labs-auth/compare/6efa57eda3bd3f93e0f245342eb2a317574c32ff...main)
 
+* [BUGFIX: Resolve Github Omniauth dependency](https://github.com/fastruby/ombu_labs-auth/pull/19)
+
+## 0.1.0 [(commits)](https://github.com/fastruby/ombu_labs-auth/compare/6efa57eda3bd3f93e0f245342eb2a317574c32ff...v0.1.0)
+
 * [FEATURE: Add Devise](https://github.com/fastruby/ombu_labs-auth/pull/2)
 * [FEATURE: Add Omniauth](https://github.com/fastruby/ombu_labs-auth/pull/3)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ GITHUB_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ```ruby
 gem 'ombu_labs-auth'
-gem 'omniauth-github', '~> 2.0.0'
 ```
 
 - And then execute:

--- a/lib/ombu_labs/auth.rb
+++ b/lib/ombu_labs/auth.rb
@@ -1,4 +1,6 @@
 require "devise"
+require "omniauth-github"
+# due to boot time configs, these need to be required BEFORE the engine
 require "ombu_labs/auth/version"
 require "ombu_labs/auth/engine"
 


### PR DESCRIPTION
- Adds an explicit `require` call for `omniauth-github` **before** requiring the engine itself
- Updates README & CHANGELOG

Fixes #14