### PR TITLE
chore(workflow): Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  release-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Release PR
+        uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: ruby
+          package-name: next_rails
+          version-file: "lib/next_rails/version.rb"
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false}, {"type":"fix","section":"Bug Fixes","hidden":false}, {"type":"chore", "section":"Miscellaneous","hidden":false}]'
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundle-cache: true
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Bundle Install
+        run: bundle install
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish to GitHub
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        env:
+          GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+          OWNER: ${{ github.repository_owner }}
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         id: release
         with:
           release-type: ruby
-          package-name: next_rails
-          version-file: "lib/next_rails/version.rb"
+          package-name: ombu_labs-auth
+          version-file: "lib/ombu_labs/auth/version.rb"
           changelog-types: '[{"type":"feat","section":"Features","hidden":false}, {"type":"fix","section":"Bug Fixes","hidden":false}, {"type":"chore", "section":"Miscellaneous","hidden":false}]'
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -77,5 +77,21 @@ Have a fix for a problem you've been running into or an idea for a new feature y
 
 Take a look at the [Contributing document](https://github.com/fastruby/ombu_labs-auth/blob/main/CONTRIBUTING.md) for instructions to set up the repo on your machine and create a good Pull Request.
 
+## Release
+
+If you are looking to contribute in the gem you need to be aware that we are using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification to release versions in this gem.
+
+which means, when doing a contribution your commit message must have the following structure
+
+```git
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+[here](https://www.conventionalcommits.org/en/v1.0.0/#examples) you can find some commit's examples.
+
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
There is the following step before merging this proposal.

Generate a token in the RubyGems account (you can scope the token per gem or global) and add it to the repo under ombu_labs-auth > settings > secrets > actions > repository secrets with the following name RUBYGEMS_AUTH_TOKEN

![image](https://user-images.githubusercontent.com/7331511/177388324-a86826fa-3d7e-41e0-b7f9-3c3e23594dac.png)
