### PR TITLE
FR-676 adjust turbo usage in sign_in button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```
 
 ## main [(unreleased)](https://github.com/fastruby/ombu_labs-auth/compare/v1.1.0...main)
+* [FEATURE: turbo: false to sign_in using oauth](https://github.com/fastruby/ombu_labs-auth/pull/26)
+
 
 *
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,5 +4,5 @@
   <div class="alert alert-danger" role="alert"><%= flash[:error] %></div>
 <% end %>
 <%- Devise.omniauth_providers.each do |provider| %>
-  <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(OmbuLabs::Auth.user_class, provider), method: :post %><br />
+  <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(OmbuLabs::Auth.user_class, provider), method: :post, data: { turbo: false } %><br />
 <% end -%>


### PR DESCRIPTION
In FastRuby we're using `Administrate` gem in version `1.0.0.beta3`
And since they moved their code to use hotwire/turbo
> [[CHANGE] [#2448] Replace jquery-ujs with @hotwired/turbo](https://github.com/thoughtbot/administrate/blob/main/CHANGELOG.md#100beta2-october-25-2024)

Turbo changes how the sign in button does the request using fetch request. Assign the sign_in button a `data: {turbo: false}` will make the button have the usual behavior with regular http requests and will not fail to have redirect from oauth providers. 
