### PR TITLE
Loosen dependency on devise and rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [BUGFIX: ---------------](https://github.com/fastruby/ombu_labs-auth/-----)
 ```
 
-## main [(unreleased)](https://github.com/fastruby/ombu_labs-auth/compare/v1.1.0...main)
+## main [(unreleased)](https://github.com/fastruby/ombu_labs-auth/compare/v1.2.0...main)
 
-*
+
+## 1.2.0 (2026-07-16) [(commits)](https://github.com/fastruby/ombu_labs-auth/compare/v1.1.1...v1.2.0)
+
+* [CHORE: Loosen dependencies on Rails and Devise](https://github.com/fastruby/ombu_labs-auth/pull/28)
 
 ## 1.1.1 (2025-08-21) [(commits)](https://github.com/fastruby/ombu_labs-auth/compare/v1.1.0...v1.1.1)
 

--- a/ombu_labs-auth.gemspec
+++ b/ombu_labs-auth.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 6.0", "< 9.0"
-  spec.add_dependency "devise", "~> 4.9"
+  spec.add_dependency "rails", ">= 6.0"
+  spec.add_dependency "devise", ">= 4.9"
   spec.add_dependency "omniauth", "~> 2.1.0"
   spec.add_dependency "omniauth-github", "~> 2.0.0"
   spec.add_dependency "omniauth-google-oauth2", "~> 1.1"


### PR DESCRIPTION
For future versions and security reasons, I think it's a good idea to not be so restrictive. 